### PR TITLE
更改delete无法释放内存的问题

### DIFF
--- a/skiplist.h
+++ b/skiplist.h
@@ -61,7 +61,7 @@ Node<K, V>::Node(const K k, const V v, int level) {
 
 template<typename K, typename V> 
 Node<K, V>::~Node() {
-    for(int i=0 ; i < node_level;i++){
+    for(int i=0 ; i < node_level + 1 ; i++){
     	delete []forward[i];
     }
     delete []forward;

--- a/skiplist.h
+++ b/skiplist.h
@@ -61,6 +61,9 @@ Node<K, V>::Node(const K k, const V v, int level) {
 
 template<typename K, typename V> 
 Node<K, V>::~Node() {
+    for(int i=0 ; i < node_level;i++){
+    	delete []forward[i];
+    }
     delete []forward;
 };
 


### PR DESCRIPTION
直接delete[]forward的话，分配给**forward的内存无法彻底删除，为了安全性，需要使用for循环来删除二维数组，放置内存泄漏