### PR TITLE
简单修改了delete_element的逻辑，在一次遍历过程中就可以删除索引和节点，不需要第二次

### DIFF
--- a/skiplist.h
+++ b/skiplist.h
@@ -393,12 +393,13 @@ SkipList<K, V>::~SkipList() {
         _file_reader.close();
     }
 
-    //递归删除跳表链条
-    if(_header->forward[0]!=nullptr){
-        clear(_header->forward[0]);
+    Node<K, V> *current = _header->forward[0];
+    while(current) {
+      _header->forward[0] = current->forward[0];
+      delete current;
+      current = _header->forward[0];
     }
-    delete(_header);
-    
+    delete _header;
 }
 template <typename K, typename V>
 void SkipList<K, V>::clear(Node<K, V> * cur)


### PR DESCRIPTION
删除是自顶向下的，删除上一层的索引不会影响下一层，所以在遍历的时候如果找到key就可以删除